### PR TITLE
Modify base.html to use a new template for including all Javascript

### DIFF
--- a/django_jasmine/templates/jasmine/base.html
+++ b/django_jasmine/templates/jasmine/base.html
@@ -23,12 +23,9 @@
     {% endfor %}
 
     {% load assets %}
-    {% for bundle in suite.bundles %}
-      <!-- Loading bundle {{ bundle }} -->
-      {% assets bundle %}
-       <script type="text/javascript" src="{{ ASSET_URL }}" data-cover></script>
-      {% endassets %}
-    {% endfor %}
+
+    <!-- The project under test must define how to include all Javascript by defining an all_js template-->
+    {% include "common/partials/all_js.html" %}
 
     {% load gears %}
     {% for root in suite.roots %}

--- a/django_jasmine/templates/jasmine/base.html
+++ b/django_jasmine/templates/jasmine/base.html
@@ -27,12 +27,6 @@
     <!-- The project under test must define how to include all Javascript by defining an all_js template-->
     {% include "common/partials/all_js.html" %}
 
-    {% load gears %}
-    {% for root in suite.roots %}
-      <!-- Loading root {{ root }} -->
-      {% js_asset_tag root %}
-    {% endfor %}
-
     {# static files #}
     {% for url in suite.static_files %}
     <script src="{% get_static_prefix %}{{ url }}"></script>


### PR DESCRIPTION
This is a short-term fix. I think longer term, we want to move to using RequireJS, which can load dependencies entirely client side. 

@karansag for review, this time with the correct base branch.
